### PR TITLE
Fix README installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This project is built with:
 git clone <repository-url>
 
 # Navigate to the project directory
-cd kitloop
+cd kitloop-gear-hub
 
 # Install dependencies
 npm install


### PR DESCRIPTION
## Summary
- correct path in README installation instructions

## Testing
- `npm run lint` *(fails: @eslint/js missing)*

------
https://chatgpt.com/codex/tasks/task_e_68586c33d190832ca080597220ce3313