### PR TITLE
Fix hero layout and navbar links

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,7 +1,6 @@
 
 import React from 'react';
 import { Button } from "@/components/ui/button";
-import Section from "@/components/ui/section";
 import { Link, useNavigate } from "react-router-dom";
 import { Search, Package } from "lucide-react";
 import SearchBar from './SearchBar';
@@ -16,7 +15,7 @@ const Hero = () => {
   };
 
   return (
-    <Section className="relative min-h-[85vh] flex items-center justify-center overflow-hidden bg-gradient-to-b from-kitloop-background to-background">
+    <section className="min-h-screen pt-24 pb-16 bg-background flex items-center relative overflow-hidden">
   <div className="absolute inset-0 z-0 opacity-20">
     <div className="absolute inset-0 bg-gradient-to-r from-kitloop-accent/20 to-transparent"></div>
     <img 
@@ -42,7 +41,7 @@ const Hero = () => {
   </Link>
 </div>
 </div>
-</Section>
+</section>
 
   );
 };

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -69,7 +69,7 @@ const HowItWorks = () => {
   ];
   
   return (
-    <section className="py-16 px-6 bg-kitloop-background">
+    <section id="how-it-works" className="py-16 px-6 bg-kitloop-background">
       <div className="container mx-auto max-w-7xl">
         <h2 className="text-3xl font-bold mb-2 text-center">{t('how_it_works.title')}</h2>
         <p className="text-muted-foreground mb-10 text-center max-w-2xl mx-auto">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -26,27 +26,28 @@ const Navbar = () => {
         {/* Logo */}
         <div className="flex-shrink-0">
           <Link to="/" className="text-2xl font-bold flex items-center">
-            <span className="text-primary mr-1">Kit</span>loop
+            <span className="text-primary">Kit</span>
+            <span className="text-text">loop</span>
           </Link>
         </div>
 
         {/* Center Navigation */}
-        <nav className="flex-1 hidden md:flex justify-center items-center gap-8">
-          <button 
-            onClick={() => scrollToSection('how-it-works')} 
-            className="hover:underline"
+        <nav className="flex-1 hidden md:flex justify-center items-center gap-8 text-text">
+          <button
+            onClick={() => scrollToSection('how-it-works')}
+            className="hover:underline transition-colors duration-200"
           >
             {t('navbar.how_it_works')}
           </button>
-          <Link to="/browse" className="hover:underline">
+          <Link to="/browse" className="hover:underline transition-colors duration-200">
             {t('navbar.browse_gear')}
           </Link>
-          <Link to="/about" className="hover:underline">
+          <Link to="/about" className="hover:underline transition-colors duration-200">
             {t('navbar.about_us')}
           </Link>
-          <button 
-            onClick={() => scrollToSection('faq')} 
-            className="hover:underline"
+          <button
+            onClick={() => scrollToSection('faq')}
+            className="hover:underline transition-colors duration-200"
           >
             {t('navbar.faq')}
           </button>


### PR DESCRIPTION
## Summary
- fix hero section container to use full-screen height
- add `how-it-works` id so nav scroll works
- make logo split color for Kit/loop
- set navbar items to black with underline hover

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1e158e8832cb980e70aa57c80a2