### PR TITLE
Fix nav smooth scrolling to home section

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -10,9 +10,11 @@ const Navbar = () => {
 
   const scrollToSection = (sectionId: string) => {
     if (window.location.pathname !== '/') {
-      navigate('/', { state: { scrollTo: sectionId } });
+      // Redirect to the homepage with the section hash so the page knows what to scroll to
+      window.location.href = `/#${sectionId}`;
       return;
     }
+
     const element = document.getElementById(sectionId);
     if (element) {
       element.scrollIntoView({ behavior: 'smooth' });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -10,15 +10,16 @@ const Index = () => {
   const location = useLocation();
 
   useEffect(() => {
-    if (location.state && location.state.scrollTo) {
-      const sectionId = location.state.scrollTo;
-      setTimeout(() => {
-        const element = document.getElementById(sectionId);
-        if (element) {
-          element.scrollIntoView({ behavior: 'smooth' });
-        }
-      }, 100);
-    }
+    const sectionId = location.state?.scrollTo || location.hash.replace('#', '');
+    if (!sectionId) return;
+
+    // Delay ensures the DOM is ready when navigating from another page
+    setTimeout(() => {
+      const element = document.getElementById(sectionId);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }
+    }, 100);
   }, [location]);
 
   return (


### PR DESCRIPTION
## Summary
- ensure nav redirect to home uses hash for target section
- auto-scroll home section if a hash or state is present

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bba4053c8832ca671e1649420a5ea