### PR TITLE
Alternate timeline layout

### DIFF
--- a/src/pages/HowItWorks.tsx
+++ b/src/pages/HowItWorks.tsx
@@ -81,77 +81,85 @@ const HowItWorks = () => {
             {/* Timeline Line */}
             <div className="hidden md:block absolute left-1/2 transform -translate-x-1/2 h-full w-1 bg-kitloop-accent/30"></div>
             
-            {/* Timeline Items */}
-            <div className="space-y-16 md:space-y-24">
-              {/* Item 1 */}
-              <div className="flex flex-col md:flex-row items-center">
-                <div className="md:w-1/2 md:pr-16 mb-6 md:mb-0 md:text-right animate-fade-in">
-                  <h3 className="text-2xl font-semibold mb-2 text-kitloop-accent">Find the perfect gear</h3>
-                  <p className="text-muted-foreground">
-                    Browse through thousands of rental options filtered by location, activity, or specific equipment type. See what's available nearby with real-time availability.
-                  </p>
-                </div>
-                <div className="relative md:w-14 h-14 rounded-full bg-kitloop-accent flex items-center justify-center z-10">
-                  <span className="text-white font-bold text-xl">1</span>
-                </div>
-                <div className="md:w-1/2 md:pl-16 md:text-left hidden md:block">
-                  <div className="bg-kitloop-light-gray rounded-lg p-8 shadow-sm hover-lift">
-                    <Search className="w-16 h-16 text-kitloop-accent mb-4" />
+              {/* Timeline Items */}
+              <div className="space-y-16 md:space-y-24">
+                {/* Item 1 */}
+                <div className="flex flex-col md:flex-row items-start">
+                  <div className="md:w-1/2 md:pr-16 mb-6 md:mb-0 flex md:justify-end animate-fade-in">
+                    <div className="flex items-center gap-4">
+                      <div className="relative w-14 h-14 rounded-full bg-kitloop-accent flex items-center justify-center z-10">
+                        <span className="text-white font-bold text-xl">1</span>
+                      </div>
+                      <h3 className="text-2xl font-semibold text-kitloop-accent">Find the perfect gear</h3>
+                    </div>
+                  </div>
+                  <div className="md:w-1/2 md:pl-16 animate-fade-in">
+                    <div className="bg-kitloop-light-gray rounded-lg p-8 shadow-sm hover-lift">
+                      <Search className="w-16 h-16 text-kitloop-accent mb-4" />
+                      <p className="text-muted-foreground">
+                        Browse through thousands of rental options filtered by location, activity, or specific equipment type. See what's available nearby with real-time availability.
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
               
               {/* Item 2 */}
-              <div className="flex flex-col md:flex-row items-center">
-                <div className="md:w-1/2 md:pr-16 mb-6 md:mb-0 text-left md:text-right hidden md:block">
-                  <div className="bg-kitloop-light-gray rounded-lg p-8 shadow-sm hover-lift">
-                    <CalendarCheck className="w-16 h-16 text-kitloop-accent mb-4" />
+              <div className="flex flex-col md:flex-row-reverse items-start">
+                <div className="md:w-1/2 md:pl-16 mb-6 md:mb-0 flex md:justify-start animate-fade-in">
+                  <div className="flex items-center gap-4">
+                    <div className="relative w-14 h-14 rounded-full bg-kitloop-accent flex items-center justify-center z-10">
+                      <span className="text-white font-bold text-xl">2</span>
+                    </div>
+                    <h3 className="text-2xl font-semibold text-kitloop-accent">Book in seconds</h3>
                   </div>
                 </div>
-                <div className="relative md:w-14 h-14 rounded-full bg-kitloop-accent flex items-center justify-center z-10">
-                  <span className="text-white font-bold text-xl">2</span>
-                </div>
-                <div className="md:w-1/2 md:pl-16 md:text-left animate-fade-in">
-                  <h3 className="text-2xl font-semibold mb-2 text-kitloop-accent">Book in seconds</h3>
-                  <p className="text-muted-foreground">
-                    Select your rental dates, add any necessary extras, and complete your booking with our secure payment system. Receive instant confirmation.
-                  </p>
+                <div className="md:w-1/2 md:pr-16 animate-fade-in">
+                  <div className="bg-kitloop-light-gray rounded-lg p-8 shadow-sm hover-lift">
+                    <CalendarCheck className="w-16 h-16 text-kitloop-accent mb-4" />
+                    <p className="text-muted-foreground">
+                      Select your rental dates, add any necessary extras, and complete your booking with our secure payment system. Receive instant confirmation.
+                    </p>
+                  </div>
                 </div>
               </div>
               
               {/* Item 3 */}
-              <div className="flex flex-col md:flex-row items-center">
-                <div className="md:w-1/2 md:pr-16 mb-6 md:mb-0 md:text-right animate-fade-in">
-                  <h3 className="text-2xl font-semibold mb-2 text-kitloop-accent">Easy pickup</h3>
-                  <p className="text-muted-foreground">
-                    Get directions to your pickup location after booking confirmation. Meet with the provider and receive your gear with a quick ID check.
-                  </p>
+              <div className="flex flex-col md:flex-row items-start">
+                <div className="md:w-1/2 md:pr-16 mb-6 md:mb-0 flex md:justify-end animate-fade-in">
+                  <div className="flex items-center gap-4">
+                    <div className="relative w-14 h-14 rounded-full bg-kitloop-accent flex items-center justify-center z-10">
+                      <span className="text-white font-bold text-xl">3</span>
+                    </div>
+                    <h3 className="text-2xl font-semibold text-kitloop-accent">Easy pickup</h3>
+                  </div>
                 </div>
-                <div className="relative md:w-14 h-14 rounded-full bg-kitloop-accent flex items-center justify-center z-10">
-                  <span className="text-white font-bold text-xl">3</span>
-                </div>
-                <div className="md:w-1/2 md:pl-16 md:text-left hidden md:block">
+                <div className="md:w-1/2 md:pl-16 animate-fade-in">
                   <div className="bg-kitloop-light-gray rounded-lg p-8 shadow-sm hover-lift">
                     <MapPin className="w-16 h-16 text-kitloop-accent mb-4" />
+                    <p className="text-muted-foreground">
+                      Get directions to your pickup location after booking confirmation. Meet with the provider and receive your gear with a quick ID check.
+                    </p>
                   </div>
                 </div>
               </div>
               
               {/* Item 4 */}
-              <div className="flex flex-col md:flex-row items-center">
-                <div className="md:w-1/2 md:pr-16 mb-6 md:mb-0 text-left md:text-right hidden md:block">
-                  <div className="bg-kitloop-light-gray rounded-lg p-8 shadow-sm hover-lift">
-                    <Star className="w-16 h-16 text-kitloop-accent mb-4" />
+              <div className="flex flex-col md:flex-row-reverse items-start">
+                <div className="md:w-1/2 md:pl-16 mb-6 md:mb-0 flex md:justify-start animate-fade-in">
+                  <div className="flex items-center gap-4">
+                    <div className="relative w-14 h-14 rounded-full bg-kitloop-accent flex items-center justify-center z-10">
+                      <span className="text-white font-bold text-xl">4</span>
+                    </div>
+                    <h3 className="text-2xl font-semibold text-kitloop-accent">Return & review</h3>
                   </div>
                 </div>
-                <div className="relative md:w-14 h-14 rounded-full bg-kitloop-accent flex items-center justify-center z-10">
-                  <span className="text-white font-bold text-xl">4</span>
-                </div>
-                <div className="md:w-1/2 md:pl-16 md:text-left animate-fade-in">
-                  <h3 className="text-2xl font-semibold mb-2 text-kitloop-accent">Return & review</h3>
-                  <p className="text-muted-foreground">
-                    Return your gear to the same location (unless specified otherwise). Share your experience with the community by leaving a helpful review.
-                  </p>
+                <div className="md:w-1/2 md:pr-16 animate-fade-in">
+                  <div className="bg-kitloop-light-gray rounded-lg p-8 shadow-sm hover-lift">
+                    <Star className="w-16 h-16 text-kitloop-accent mb-4" />
+                    <p className="text-muted-foreground">
+                      Return your gear to the same location (unless specified otherwise). Share your experience with the community by leaving a helpful review.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- alternate item layout in `HowItWorks` timeline
- keep existing styles while swapping sides for odd/even steps

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bc0cd7654832ca0e0b295b4f0e272