### PR TITLE
Standardize green palette

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,16 +13,16 @@ Maintain clean, readable, and scalable styling practices
 🎯 Brand Color Rules
 Primary Brand Color
 PurposeHEXTailwind Class
-Primary color#00856Fkitloop-accent
-Hover variant#00745Ekitloop-accent-hover
+Accent gradientfrom-green-400 to-green-600bg-gradient-to-br
+Solid color#16a34abg-green-600
 
 Allowed:
 
-bg-kitloop-accent
+bg-gradient-to-br from-green-400 to-green-600
 
-text-kitloop-accent
+text-green-600
 
-hover:bg-kitloop-accent-hover
+bg-green-600
 
 Not allowed:
 

--- a/src/components/home/CallToAction.tsx
+++ b/src/components/home/CallToAction.tsx
@@ -8,7 +8,7 @@ const CallToAction = () => {
   const { t } = useTranslation();
   
   return (
-    <Section className="bg-gradient-to-br from-kitloop-accent/20 to-background">
+    <Section className="bg-gradient-to-br from-green-400 to-green-600">
       <div className="container mx-auto max-w-4xl text-center">
         <h2 className="text-3xl md:text-4xl font-bold mb-4">{t('cta.title')}</h2>
         <p className="text-lg mb-8 max-w-2xl mx-auto">

--- a/src/components/home/FAQ.tsx
+++ b/src/components/home/FAQ.tsx
@@ -154,14 +154,14 @@ const FAQ = () => {
                       value={category.category}
                       className={`
                         justify-start text-left p-3 h-auto 
-                        ${isMobile ? 'border-b-2 border-b-transparent data-[state=active]:border-b-kitloop-accent' : 'border-l-2 border-transparent data-[state=active]:border-l-kitloop-accent'}
-                        data-[state=active]:bg-muted data-[state=active]:text-kitloop-accent font-medium
+                        ${isMobile ? 'border-b-2 border-b-transparent data-[state=active]:border-b-green-600' : 'border-l-2 border-transparent data-[state=active]:border-l-green-600'}
+                        data-[state=active]:bg-muted data-[state=active]:text-green-600 font-medium
                         ${isMobile ? 'rounded-md whitespace-nowrap min-w-max' : 'w-full rounded-r-md'}
                       `}
                     >
                       <div className={`flex items-center gap-3 ${isMobile ? 'flex-col text-xs' : ''}`}>
                         <div className={`flex items-center justify-center ${isMobile ? 'w-8 h-8' : 'w-10 h-10'} rounded-full bg-muted`}>
-                          <Icon size={isMobile ? 16 : 20} className="text-kitloop-accent" />
+                          <Icon size={isMobile ? 16 : 20} className="text-green-600" />
                         </div>
                         <span className="font-medium">{category.title}</span>
                       </div>

--- a/src/components/home/FeaturedGear.tsx
+++ b/src/components/home/FeaturedGear.tsx
@@ -15,7 +15,7 @@ const GearCard = ({ item }: { item: FeaturedGearItem }) => {
     <Card className="overflow-hidden border-none shadow-md hover-lift h-full flex flex-col">
       <div className="relative h-52 bg-background">
         {item.is_new && (
-          <Badge className="absolute top-2 right-2 bg-kitloop-accent text-white">
+          <Badge className="absolute top-2 right-2">
             New
           </Badge>
         )}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -17,7 +17,7 @@ const Hero = () => {
   return (
     <section className="min-h-screen pt-24 pb-16 bg-background flex items-center relative overflow-hidden">
   <div className="absolute inset-0 z-0 opacity-20">
-    <div className="absolute inset-0 bg-gradient-to-r from-kitloop-accent/20 to-transparent"></div>
+    <div className="absolute inset-0 bg-gradient-to-r from-green-400 to-green-600"></div>
     <img 
       src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&q=80" 
       alt={t('hero.image_alt')} 
@@ -27,7 +27,7 @@ const Hero = () => {
 
   <div className="container mx-auto relative z-10 flex flex-col items-center text-center max-w-4xl">
     <h1 className="text-4xl md:text-6xl font-bold mb-6 text-kitloop-text text-shadow">
-      <span className="text-kitloop-accent">{t('hero.headline')}</span>
+      <span className="text-green-600">{t('hero.headline')}</span>
     </h1>
 
     <div className="w-full max-w-2xl mb-8">
@@ -36,7 +36,7 @@ const Hero = () => {
 
 <div className="mt-4 text-sm text-muted-foreground">
   Are you a rental provider?{" "}
-  <Link to="/add-rental" className="underline text-primary hover:text-primaryDark">
+  <Link to="/add-rental" className="underline text-green-600 hover:text-green-600">
     Add your gear here.
   </Link>
 </div>

--- a/src/components/home/HeroSectionA.tsx
+++ b/src/components/home/HeroSectionA.tsx
@@ -19,7 +19,7 @@ const HeroSectionA = () => {
   };
 
   return (
-    <section className="bg-primary text-foreground py-16 sm:py-24">
+    <section className="bg-green-600 text-foreground py-16 sm:py-24">
       <div className="container mx-auto max-w-2xl px-4 text-center space-y-8">
         <div>
           <h1 className="text-5xl sm:text-6xl font-bold mb-4">

--- a/src/components/home/HeroSectionB.tsx
+++ b/src/components/home/HeroSectionB.tsx
@@ -19,7 +19,7 @@ const HeroSectionB = () => {
   };
 
   return (
-    <section className="bg-primary text-foreground py-16 sm:py-24">
+    <section className="bg-green-600 text-foreground py-16 sm:py-24">
       <div className="container mx-auto max-w-6xl px-4 flex flex-col lg:flex-row items-center gap-12">
         <div className="flex-1 text-center lg:text-left space-y-6">
           <h1 className="text-5xl md:text-7xl font-bold">

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -57,14 +57,14 @@ const HowItWorks = () => {
       title: t('how_it_works.step_3_title'),
       description: t('how_it_works.step_3_description'),
       icon: CheckCircle,
-      color: "bg-primary/20 text-primary"
+      color: "bg-gradient-to-br from-green-400 to-green-600 text-white"
     },
     {
       id: 4,
       title: t('how_it_works.step_4_title'),
       description: t('how_it_works.step_4_description'),
       icon: ArrowRight,
-      color: "bg-primary/20 text-primary"
+      color: "bg-gradient-to-br from-green-400 to-green-600 text-white"
     }
   ];
   

--- a/src/components/home/MapSection.tsx
+++ b/src/components/home/MapSection.tsx
@@ -14,7 +14,7 @@ const MapSection = () => {
             </p>
             <ul className="space-y-3">
               <li className="flex items-start">
-                <div className="bg-kitloop-accent rounded-full p-1 mr-3 mt-1">
+                <div className="bg-gradient-to-br from-green-400 to-green-600 rounded-full p-1 mr-3 mt-1">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>
@@ -22,7 +22,7 @@ const MapSection = () => {
                 <span>Over 500 verified rental providers nationwide</span>
               </li>
               <li className="flex items-start">
-                <div className="bg-kitloop-accent rounded-full p-1 mr-3 mt-1">
+                <div className="bg-gradient-to-br from-green-400 to-green-600 rounded-full p-1 mr-3 mt-1">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>
@@ -30,7 +30,7 @@ const MapSection = () => {
                 <span>Easy pickup options or delivery available</span>
               </li>
               <li className="flex items-start">
-                <div className="bg-kitloop-accent rounded-full p-1 mr-3 mt-1">
+                <div className="bg-gradient-to-br from-green-400 to-green-600 rounded-full p-1 mr-3 mt-1">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M20 6L9 17L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>

--- a/src/components/home/SearchBar.tsx
+++ b/src/components/home/SearchBar.tsx
@@ -29,7 +29,7 @@ const SearchBar = () => {
       <div className="relative flex-grow">
         <Input 
           placeholder={t('hero.search_placeholder')} 
-          className="pl-10 py-6 bg-white/90 backdrop-blur-sm border-kitloop-medium-gray focus:border-kitloop-accent"
+          className="pl-10 py-6 bg-white/90 backdrop-blur-sm border-kitloop-medium-gray focus:border-green-600"
           value={gearQuery}
           onChange={(e) => setGearQuery(e.target.value)}
         />
@@ -38,7 +38,7 @@ const SearchBar = () => {
       <div className="relative flex-grow">
         <Input 
           placeholder={t('hero.location_placeholder')} 
-          className="pl-10 py-6 bg-white/90 backdrop-blur-sm border-kitloop-medium-gray focus:border-kitloop-accent"
+          className="pl-10 py-6 bg-white/90 backdrop-blur-sm border-kitloop-medium-gray focus:border-green-600"
           value={locationQuery}
           onChange={(e) => setLocationQuery(e.target.value)}
         />

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -25,7 +25,7 @@ const Footer = () => {
           {/* About */}
           <div>
             <h3 className="font-bold text-xl mb-4">
-              <span className="text-kitloop-accent">Kit</span>loop
+              <span className="text-green-600">Kit</span>loop
             </h3>
             <p className="text-muted-foreground mb-4">
               Making outdoor gear rental fast, simple, and seamless. Access over ownership.
@@ -37,17 +37,17 @@ const Footer = () => {
             <h3 className="font-bold mb-4">Discover</h3>
             <ul className="space-y-2">
               <li>
-                <Link to="/browse" className="text-muted-foreground hover:text-kitloop-accent transition-colors">
+                <Link to="/browse" className="text-muted-foreground hover:text-green-600 transition-colors">
                   {t('footer.browse')}
                 </Link>
               </li>
               <li>
-                <Link to="/how-it-works" className="text-muted-foreground hover:text-kitloop-accent transition-colors">
+                <Link to="/how-it-works" className="text-muted-foreground hover:text-green-600 transition-colors">
                   {t('footer.how_it_works')}
                 </Link>
               </li>
               <li>
-                <Link to="/about" className="text-muted-foreground hover:text-kitloop-accent transition-colors">
+                <Link to="/about" className="text-muted-foreground hover:text-green-600 transition-colors">
                   {t('footer.about')}
                 </Link>
               </li>
@@ -59,14 +59,14 @@ const Footer = () => {
             <h3 className="font-bold mb-4">Support</h3>
             <ul className="space-y-2">
               <li>
-                <a href="mailto:info@kitloop.app" className="text-muted-foreground hover:text-kitloop-accent transition-colors">
+                <a href="mailto:info@kitloop.app" className="text-muted-foreground hover:text-green-600 transition-colors">
                   {t('footer.contact')}
                 </a>
               </li>
               <li>
                 <button
                   onClick={() => scrollToSection('faq')}
-                  className="text-muted-foreground hover:text-kitloop-accent transition-colors text-left"
+                  className="text-muted-foreground hover:text-green-600 transition-colors text-left"
                 >
                   {t('footer.faq')}
                 </button>
@@ -79,12 +79,12 @@ const Footer = () => {
             <h3 className="font-bold mb-4">Legal</h3>
             <ul className="space-y-2">
               <li>
-                <Link to="/terms" className="text-muted-foreground hover:text-kitloop-accent transition-colors">
+                <Link to="/terms" className="text-muted-foreground hover:text-green-600 transition-colors">
                   {t('footer.terms')}
                 </Link>
               </li>
               <li>
-                <Link to="/privacy" className="text-muted-foreground hover:text-kitloop-accent transition-colors">
+                <Link to="/privacy" className="text-muted-foreground hover:text-green-600 transition-colors">
                   {t('footer.privacy')}
                 </Link>
               </li>

--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -13,7 +13,7 @@ const LanguageSwitcher = () => {
   return (
     <button
       onClick={toggleLanguage}
-      className="text-sm font-medium text-kitloop-text hover:text-kitloop-accent transition-colors"
+      className="text-sm font-medium text-kitloop-text hover:text-green-600 transition-colors"
     >
       {currentLang === "cs" ? "🇨🇿 CZ" : "🇺🇸 EN"}
     </button>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -22,13 +22,13 @@ const Navbar = () => {
   };
 
   return (
-    <header className="py-4 px-6 md:px-10 bg-white text-primary fixed top-0 left-0 right-0 z-50 shadow-sm">
+    <header className="py-4 px-6 md:px-10 bg-white text-green-600 fixed top-0 left-0 right-0 z-50 shadow-sm">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         
         {/* Logo */}
         <div className="flex-shrink-0">
           <Link to="/" className="text-2xl font-bold flex items-center">
-            <span className="text-primary pr-0.5 tracking-tight">Kit</span>
+            <span className="text-green-600 pr-0.5 tracking-tight">Kit</span>
             <span className="text-text tracking-wide">loop</span>
           </Link>
         </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-sm bg-primary text-white text-xs px-2 py-1"
+  "inline-flex items-center rounded-sm bg-gradient-to-br from-green-400 to-green-600 text-white text-xs px-2 py-1"
 )
 
 function Badge({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,9 +9,9 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary: "bg-primary text-white hover:bg-primaryDark",
-        outline: "border border-primary text-primary hover:bg-primary hover:text-white",
-        ghost: "text-primary hover:underline",
+        primary: "bg-green-600 text-white hover:bg-green-600",
+        outline: "border border-green-600 text-green-600 hover:bg-green-600 hover:text-white",
+        ghost: "text-green-600 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -41,7 +41,7 @@ function Calendar({
         ),
         day_range_end: "day-range-end",
         day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+          "bg-green-600 text-white hover:bg-green-600 hover:text-white focus:bg-green-600 focus:text-white",
         day_today: "bg-accent text-accent-foreground",
         day_outside:
           "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer h-4 w-4 shrink-0 rounded-sm border border-green-600 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-green-600 data-[state=checked]:text-white",
       className
     )}
     {...props}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -16,7 +16,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="h-full w-full flex-1 bg-green-600 transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -26,7 +26,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-green-600 text-green-600 ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -16,9 +16,9 @@ const Slider = React.forwardRef<
     {...props}
   >
     <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      <SliderPrimitive.Range className="absolute h-full bg-green-600" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-green-600 bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -16,7 +16,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+            "group-[.toast]:bg-green-600 group-[.toast]:text-white",
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
         },

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-input",
       className
     )}
     {...props}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -15,7 +15,7 @@ const About = () => {
           <h1 className="text-4xl md:text-5xl font-bold mb-10 text-center">{t('about.title')}</h1>
           
           <div className="mb-16">
-            <h2 className="text-3xl font-bold mb-6 text-kitloop-accent">{t('about.why_kitloop.title')}</h2>
+            <h2 className="text-3xl font-bold mb-6 text-green-600">{t('about.why_kitloop.title')}</h2>
             <div className="space-y-4 text-lg">
               <p>
                 {t('about.why_kitloop.paragraph1')}
@@ -31,7 +31,7 @@ const About = () => {
           
           {/* Section 2: About the Founder */}
           <div className="mb-12">
-            <h2 className="text-3xl font-bold mb-8 text-kitloop-accent">{t('about.founder.title')}</h2>
+            <h2 className="text-3xl font-bold mb-8 text-green-600">{t('about.founder.title')}</h2>
             <div className="flex flex-col md:flex-row gap-8 items-center">
               <div className="md:w-1/2 space-y-4 text-lg">
                 <p>
@@ -56,7 +56,7 @@ const About = () => {
           
           {/* Optional CTA */}
           <div className="text-center mt-16">
-            <Button asChild className="bg-kitloop-accent hover:bg-kitloop-accent-hover text-white px-8 py-6 text-lg">
+            <Button asChild className="bg-green-600 hover:bg-green-600 text-white px-8 py-6 text-lg">
               <Link to="/add-rental">{t('about.cta')}</Link>
             </Button>
           </div>

--- a/src/pages/AddRental.tsx
+++ b/src/pages/AddRental.tsx
@@ -91,8 +91,8 @@ const AddRental = () => {
         <div className="max-w-4xl mx-auto">
           <div className="bg-background rounded-lg p-6 md:p-10 shadow-sm">
             <div className="flex flex-col items-center text-center">
-              <div className="w-16 h-16 bg-kitloop-accent/10 rounded-full flex items-center justify-center mb-6">
-                <CheckCircle className="h-8 w-8 text-kitloop-accent" />
+              <div className="w-16 h-16 rounded-full flex items-center justify-center mb-6 bg-gradient-to-br from-green-400 to-green-600">
+                <CheckCircle className="h-8 w-8 text-white" />
               </div>
               <h2 className="text-2xl md:text-3xl font-bold mb-4">Thank You for Your Submission!</h2>
               <div className="max-w-lg">
@@ -130,49 +130,49 @@ const AddRental = () => {
           
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-10">
             <div className="bg-kitloop-background rounded-lg p-6 flex flex-col items-center text-center">
-              <div className="bg-kitloop-accent/10 rounded-full p-4 mb-4">
-                <Package className="h-8 w-8 text-kitloop-accent" />
+              <div className="rounded-full p-4 mb-4 bg-gradient-to-br from-green-400 to-green-600">
+                <Package className="h-8 w-8 text-white" />
               </div>
               <h3 className="text-xl font-semibold mb-2">Why list your gear?</h3>
               <ul className="text-left space-y-3 mt-4">
                 <li className="flex items-start">
-                  <CheckCircle className="h-5 w-5 text-kitloop-accent mr-2 shrink-0 mt-0.5" />
+                  <CheckCircle className="h-5 w-5 text-green-600 mr-2 shrink-0 mt-0.5" />
                   <span>Earn extra income from gear you already own</span>
                 </li>
                 <li className="flex items-start">
-                  <CheckCircle className="h-5 w-5 text-kitloop-accent mr-2 shrink-0 mt-0.5" />
+                  <CheckCircle className="h-5 w-5 text-green-600 mr-2 shrink-0 mt-0.5" />
                   <span>Help others access quality outdoor equipment</span>
                 </li>
                 <li className="flex items-start">
-                  <CheckCircle className="h-5 w-5 text-kitloop-accent mr-2 shrink-0 mt-0.5" />
+                  <CheckCircle className="h-5 w-5 text-green-600 mr-2 shrink-0 mt-0.5" />
                   <span>Simple booking and secure payment system</span>
                 </li>
                 <li className="flex items-start">
-                  <CheckCircle className="h-5 w-5 text-kitloop-accent mr-2 shrink-0 mt-0.5" />
+                  <CheckCircle className="h-5 w-5 text-green-600 mr-2 shrink-0 mt-0.5" />
                   <span>Full control over pricing and availability</span>
                 </li>
               </ul>
             </div>
             
-            <div className="bg-gradient-to-br from-kitloop-accent/10 to-transparent rounded-lg p-6">
+            <div className="bg-gradient-to-br from-green-400 to-green-600 rounded-lg p-6">
               <h3 className="text-xl font-semibold mb-4">How it works</h3>
               <ol className="space-y-4">
                 <li className="flex items-start">
-                  <div className="bg-kitloop-accent rounded-full h-6 w-6 text-white flex items-center justify-center mr-3 shrink-0 mt-0.5">1</div>
+                  <div className="bg-gradient-to-br from-green-400 to-green-600 rounded-full h-6 w-6 text-white flex items-center justify-center mr-3 shrink-0 mt-0.5">1</div>
                   <div>
                     <h4 className="font-medium">Submit your gear</h4>
                     <p className="text-sm text-gray-600">Fill out this form with details about your equipment</p>
                   </div>
                 </li>
                 <li className="flex items-start">
-                  <div className="bg-kitloop-accent rounded-full h-6 w-6 text-white flex items-center justify-center mr-3 shrink-0 mt-0.5">2</div>
+                  <div className="bg-gradient-to-br from-green-400 to-green-600 rounded-full h-6 w-6 text-white flex items-center justify-center mr-3 shrink-0 mt-0.5">2</div>
                   <div>
                     <h4 className="font-medium">Verification</h4>
                     <p className="text-sm text-gray-600">Our team reviews your listing for quality assurance</p>
                   </div>
                 </li>
                 <li className="flex items-start">
-                  <div className="bg-kitloop-accent rounded-full h-6 w-6 text-white flex items-center justify-center mr-3 shrink-0 mt-0.5">3</div>
+                  <div className="bg-gradient-to-br from-green-400 to-green-600 rounded-full h-6 w-6 text-white flex items-center justify-center mr-3 shrink-0 mt-0.5">3</div>
                   <div>
                     <h4 className="font-medium">Start renting</h4>
                     <p className="text-sm text-gray-600">Receive booking requests and earn income</p>
@@ -186,7 +186,7 @@ const AddRental = () => {
             <form onSubmit={onSubmit} className="space-y-6">
               <h2 className="text-2xl font-semibold mb-6">Your Information</h2>
               
-              <Alert className="mb-6 bg-kitloop-accent/5 border-kitloop-accent/20">
+              <Alert className="mb-6 bg-green-600/5 border-green-600/20">
                 <AlertDescription>
                   Your listing will be reviewed by our team before it goes live on Kitloop. We do this to ensure a safe and high-quality experience for everyone.
                 </AlertDescription>

--- a/src/pages/BrowseGear.tsx
+++ b/src/pages/BrowseGear.tsx
@@ -116,8 +116,8 @@ const GearCard = ({ gear }: { gear: typeof sampleGear[0] }) => {
       <CardContent className="p-4">
         <h3 className="font-medium line-clamp-2 mb-1 h-12">{gear.name}</h3>
         <div className="flex items-center justify-between mt-2">
-          <p className="font-bold text-kitloop-accent">{gear.price} CZK/day</p>
-          <Button size="sm" className="bg-kitloop-accent hover:bg-kitloop-accent-hover text-white">
+          <p className="font-bold text-green-600">{gear.price} CZK/day</p>
+          <Button size="sm" className="bg-green-600 hover:bg-green-600 text-white">
             {t('browse.reserve')}
           </Button>
         </div>
@@ -442,7 +442,7 @@ const BrowseGear = () => {
                 className="w-full"
               />
             </div>
-            <Button type="submit" className="bg-kitloop-accent hover:bg-kitloop-accent-hover text-white">
+            <Button type="submit" className="bg-green-600 hover:bg-green-600 text-white">
               {t('browse.search')}
             </Button>
           </form>

--- a/src/pages/HowItWorks.tsx
+++ b/src/pages/HowItWorks.tsx
@@ -41,19 +41,31 @@ const process = [
     title: "Booking secured",
     description:
       "You book the gear – we immediately notify the provider and hold your payment securely until return.",
-    icon: <HandCoins className="w-6 h-6 text-kitloop-accent" />,
+    icon: (
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gradient-to-br from-green-400 to-green-600">
+        <HandCoins className="w-4 h-4 text-white" />
+      </div>
+    ),
   },
   {
     title: "Provider prepares",
     description:
       "The provider confirms availability, prepares everything for pickup, and marks return in the system.",
-    icon: <CheckCircle className="w-6 h-6 text-kitloop-accent" />,
+    icon: (
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gradient-to-br from-green-400 to-green-600">
+        <CheckCircle className="w-4 h-4 text-white" />
+      </div>
+    ),
   },
   {
     title: "Automatic payout",
     description:
       "After successful return, the provider is paid out automatically. Kitloop support steps in if needed.",
-    icon: <ShieldCheck className="w-6 h-6 text-kitloop-accent" />,
+    icon: (
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gradient-to-br from-green-400 to-green-600">
+        <ShieldCheck className="w-4 h-4 text-white" />
+      </div>
+    ),
   },
 ];
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -56,7 +56,7 @@ const Login = () => {
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <label htmlFor="password" className="text-sm font-medium">{t('login.password')}</label>
-                <Link to="/forgot-password" className="text-sm font-medium text-primary hover:underline">
+                <Link to="/forgot-password" className="text-sm font-medium text-green-600 hover:underline">
                   {t('login.forgot_password')}
                 </Link>
               </div>
@@ -82,7 +82,7 @@ const Login = () => {
         <CardFooter className="flex flex-col space-y-3">
           <div className="text-center text-sm">
             {t('login.no_account')}{' '}
-            <Link to="/signup" className="text-primary hover:underline font-medium">
+            <Link to="/signup" className="text-green-600 hover:underline font-medium">
               {t('login.create_account')}
             </Link>
           </div>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -16,7 +16,7 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-primary hover:text-primaryDark underline">
+        <a href="/" className="text-green-600 hover:text-green-600 underline">
           Return to Home
         </a>
       </div>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -121,7 +121,7 @@ const SignUp = () => {
         <CardFooter className="flex flex-col space-y-3">
           <div className="text-center text-sm">
             {t('signup.have_account')}{' '}
-            <Link to="/login" className="text-primary hover:underline font-medium">
+            <Link to="/login" className="text-green-600 hover:underline font-medium">
               {t('signup.sign_in')}
             </Link>
           </div>


### PR DESCRIPTION
## Summary
- update docs with new green palette
- convert components to from-green-400/to-green-600 gradient
- use solid green-600 for text and hover states
- adjust accent color usages in pages and shared UI components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d017c6f18832ca46860cb65324cd4