### PR TITLE
Add Poppins heading font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -41,11 +42,11 @@
   }
 
   h1 {
-    @apply text-4xl font-bold;
+    @apply font-heading text-4xl font-bold;
   }
 
   h2 {
-    @apply text-3xl font-semibold;
+    @apply font-heading text-3xl font-semibold;
   }
 
   p {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
 import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
@@ -83,7 +84,8 @@ export default {
 				'fade-out': 'fade-out 0.4s ease-out'
 			},
                         fontFamily: {
-                                sans: ['Inter', 'sans-serif'],
+                                sans: ["Inter", ...fontFamily.sans],
+                                heading: ["Poppins", "sans-serif"],
                         }
                }
        },


### PR DESCRIPTION
## Summary
- import Poppins and update base styles for headings
- extend Tailwind config to define `heading` font family for Poppins

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d0a941ed0832cb50be43a7a124565