### PR TITLE
Finalize frontend polish

### DIFF
--- a/src/components/home/FeaturedGear.tsx
+++ b/src/components/home/FeaturedGear.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
 import { useTranslation } from "react-i18next";
@@ -12,17 +13,16 @@ type FeaturedGearItem = Database["public"]["Tables"]["featured_gear"]["Row"];
 
 const GearCard = ({ item }: { item: FeaturedGearItem }) => {
   return (
-    <Card className="overflow-hidden border-none shadow-md hover-lift h-full flex flex-col">
+    <Card className="overflow-hidden border-none shadow-md hover:-translate-y-1 hover:shadow-lg transition-transform h-full flex flex-col">
       <div className="relative h-52 bg-background">
         {item.is_new && (
-          <Badge className="absolute top-2 right-2">
-            New
-          </Badge>
+          <Badge className="absolute top-2 right-2">New</Badge>
         )}
         <img
-          src={item.image_url}
-          alt={item.name ?? ""}
-          className="h-full w-full object-contain p-4"
+          src={item.image_url || '/placeholder.svg'}
+          onError={(e) => ((e.currentTarget as HTMLImageElement).src = '/placeholder.svg')}
+          alt={item.name ?? ''}
+          className="h-full w-full object-contain p-4 transition-transform duration-300 group-hover:scale-105"
         />
       </div>
       <CardContent className="p-5 flex-grow">
@@ -34,6 +34,7 @@ const GearCard = ({ item }: { item: FeaturedGearItem }) => {
           </p>
         </div>
         <p className="text-muted-foreground text-sm mt-1">{item.provider}</p>
+        <p className="text-muted-foreground text-xs">Camping • Prague</p>
       </CardContent>
       <CardFooter className="px-5 py-3 border-t border-gray-100 flex justify-between items-center">
         <div className="flex items-center">
@@ -52,6 +53,7 @@ const GearCard = ({ item }: { item: FeaturedGearItem }) => {
 const FeaturedGear = () => {
   const [gearList, setGearList] = useState<FeaturedGearItem[]>([]);
   const [showAll, setShowAll] = useState(false);
+  const [loading, setLoading] = useState(true);
 const { t } = useTranslation();
 
   useEffect(() => {
@@ -65,6 +67,7 @@ const { t } = useTranslation();
       } else {
         setGearList(data ?? []);
       }
+      setLoading(false);
     };
 
     fetchGear();
@@ -81,9 +84,13 @@ const { t } = useTranslation();
         </p>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {displayedGear.map((item) => (
-            <GearCard key={item.id} item={item} />
-          ))}
+          {loading
+            ? Array.from({ length: 8 }).map((_, i) => (
+                <Skeleton key={i} className="h-72 w-full" />
+              ))
+            : displayedGear.map((item) => (
+                <GearCard key={item.id} item={item} />
+              ))}
         </div>
 
         {gearList.length > 8 && (

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import { Button } from "@/components/ui/button";
 import { Link, useNavigate } from "react-router-dom";
-import { Search, Package } from "lucide-react";
 import SearchBar from './SearchBar';
 import { useTranslation } from "react-i18next";
 
@@ -26,21 +25,21 @@ const Hero = () => {
   </div>
 
   <div className="container mx-auto relative z-10 flex flex-col items-center text-center max-w-4xl">
-    <h1 className="text-4xl md:text-6xl font-bold mb-6 text-kitloop-text text-shadow">
+    <h1 className="text-4xl md:text-6xl font-bold mb-4 text-kitloop-text text-shadow">
       <span className="text-green-600">{t('hero.headline')}</span>
     </h1>
+    <p className="text-lg md:text-xl text-kitloop-text mb-6 max-w-2xl">
+      {t('hero.description')}
+    </p>
 
-    <div className="w-full max-w-2xl mb-8">
+    <div className="w-full max-w-2xl mb-6">
       <SearchBar />
     </div>
 
-<div className="mt-4 text-sm text-muted-foreground">
-  Are you a rental provider?{" "}
-  <Link to="/add-rental" className="underline text-green-600 hover:text-green-600">
-    Add your gear here.
-  </Link>
-</div>
-</div>
+    <Button variant="ghost" asChild className="text-lg">
+      <Link to="/add-rental">{t('hero.add_rental')}</Link>
+    </Button>
+  </div>
 </section>
 
   );

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -1,6 +1,5 @@
 
 import React from 'react';
-import { Card, CardContent } from "@/components/ui/card";
 import { Link } from "react-router-dom";
 import { Search, Calendar, CheckCircle, ArrowRight, type LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -14,23 +13,16 @@ interface Step {
   color: string;
 }
 
-const StepCard = ({ step }: { step: Step }) => {
+const StepItem = ({ step }: { step: Step }) => {
   const IconComponent = step.icon;
-  
   return (
-    <Card className="border-none shadow-md bg-background hover-lift">
-      <CardContent className="p-6 flex flex-col items-center text-center">
-        <div className={`w-16 h-16 rounded-full ${step.color} flex items-center justify-center mb-4`}>
-          <IconComponent className="h-8 w-8" />
-        </div>
-        <h3 className="text-xl font-semibold mb-2">
-          {step.title}
-        </h3>
-        <p className="text-muted-foreground">
-          {step.description}
-        </p>
-      </CardContent>
-    </Card>
+    <li className="mb-10 ml-6 relative pl-8">
+      <span className={`absolute left-0 top-0 flex h-6 w-6 items-center justify-center rounded-full ${step.color}`}>
+        <IconComponent className="w-3 h-3" />
+      </span>
+      <h3 className="font-semibold text-lg">{step.title}</h3>
+      <p className="text-muted-foreground text-sm">{step.description}</p>
+    </li>
   );
 };
 
@@ -76,11 +68,11 @@ const HowItWorks = () => {
           {t('how_it_works.subtitle')}
         </p>
         
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
-          {steps.map(step => (
-            <StepCard key={step.id} step={step} />
+        <ol className="relative border-l border-gray-300 max-w-xl mx-auto mb-12">
+          {steps.map((step) => (
+            <StepItem key={step.id} step={step} />
           ))}
-        </div>
+        </ol>
         
         <div className="text-center">
           <Button asChild variant="primary">

--- a/src/components/home/SearchBar.tsx
+++ b/src/components/home/SearchBar.tsx
@@ -46,7 +46,12 @@ const SearchBar = () => {
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
         </div>
       </div>
-      <Button type="submit" variant="primary" className="py-6 px-8 whitespace-nowrap">
+      <Button
+        type="submit"
+        variant="primary"
+        aria-label={t('hero.cta')}
+        className="py-6 px-10 text-lg md:text-xl shadow-lg whitespace-nowrap"
+      >
         {t('hero.cta')}
       </Button>
     </form>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -18,9 +18,9 @@ const Footer = () => {
   };
 
   return (
-    <footer className="bg-background py-12 px-6 border-t border-gray-100">
+    <footer className="bg-background py-12 px-6 border-t border-gray-200">
       <div className="container mx-auto max-w-7xl">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-8">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-8 mb-8">
           
           {/* About */}
           <div>
@@ -71,6 +71,11 @@ const Footer = () => {
                   {t('footer.faq')}
                 </button>
               </li>
+              <li>
+                <Link to="/add-rental" className="text-muted-foreground hover:text-green-600 transition-colors">
+                  {t('hero.add_rental')}
+                </Link>
+              </li>
             </ul>
           </div>
 
@@ -86,6 +91,11 @@ const Footer = () => {
               <li>
                 <Link to="/privacy" className="text-muted-foreground hover:text-green-600 transition-colors">
                   {t('footer.privacy')}
+                </Link>
+              </li>
+              <li>
+                <Link to="/cookies" className="text-muted-foreground hover:text-green-600 transition-colors">
+                  {t('footer.cookies')}
                 </Link>
               </li>
             </ul>

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -21,6 +21,7 @@
     "contact": "Kontakt",
     "privacy": "Zásady ochrany osobních údajů",
     "terms": "Obchodní podmínky",
+    "cookies": "Cookies",
     "copyright": "© {{year}} Kitloop. Všechna práva vyhrazena."
   },
   "navbar": {
@@ -97,13 +98,13 @@
     "subtitle": "Půjčování outdoorového vybavení nikdy nebylo jednodušší",
     "learn_more": "Zjistěte více o tom, jak to funguje",
     "step_1_title": "Vyberte",
-    "step_1_description": "Procházejte naši nabídku vybavení od ověřených poskytovatelů půjčoven.",
+    "step_1_description": "Procházejte vybavení od ověřených poskytovatelů ve vašem okolí.",
     "step_2_title": "Rezervujte",
-    "step_2_description": "Vyberte termíny a zaplaťte bezpečně online. Žádné telefonáty nejsou potřeba.",
+    "step_2_description": "Zvolte termíny, zaplaťte online a ihned máte potvrzeno.",
     "step_3_title": "Vyzvedněte",
-    "step_3_description": "Vyzvedněte si vybavení z půjčovny nebo si ho nechte doručit.",
+    "step_3_description": "Pokyny k vyzvednutí obdržíte po potvrzení rezervace.",
     "step_4_title": "Vraťte",
-    "step_4_description": "Vraťte vybavení v dohodnutém termínu. Bez starostí, bez překvapení."
+    "step_4_description": "Vraťte vybavení včas a zanechte hodnocení."
   },
   "featured": {
   "expand": "Zobrazit více vybavení",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,6 +21,7 @@
     "contact": "Contact",
     "privacy": "Privacy Policy",
     "terms": "Terms of Service",
+    "cookies": "Cookies",
     "copyright": "© {{year}} Kitloop. All rights reserved."
   },
   "navbar": {
@@ -97,13 +98,13 @@
     "subtitle": "Renting outdoor gear has never been easier",
     "learn_more": "Learn more about how it works",
     "step_1_title": "Choose",
-    "step_1_description": "Browse through our selection of gear from verified rental providers.",
+    "step_1_description": "Browse gear from verified providers near you.",
     "step_2_title": "Reserve",
-    "step_2_description": "Select your dates and pay securely online. No more phone calls needed.",
+    "step_2_description": "Select your dates, pay securely online and get instant confirmation.",
     "step_3_title": "Pick up",
-    "step_3_description": "Get your gear from the rental shop or have it delivered to you.",
+    "step_3_description": "Pickup point is shared right after booking confirmation.",
     "step_4_title": "Return",
-    "step_4_description": "Return the gear at the agreed time. No hassle, no surprises."
+    "step_4_description": "Return the gear on time and leave a review."
    },
     "featured": {
   "expand": "Show more gear",


### PR DESCRIPTION
## Summary
- enlarge hero CTA and add tagline and secondary button
- refine Featured Gear cards with skeleton loading and hover
- display steps in a vertical timeline
- tweak footer layout and translations
- update translations for new copy

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d124e84d8832caea8c0ce3d0aa9e2