### PR TITLE
Improve responsive layout

### DIFF
--- a/src/components/home/CategorySection.tsx
+++ b/src/components/home/CategorySection.tsx
@@ -40,9 +40,11 @@ const CategoryCard = ({ category }: { category: typeof categories[0] }) => {
   };
   
   return (
-    <Card 
+    <Card
       className="overflow-hidden border-none shadow-md hover-lift group cursor-pointer"
       onClick={handleClick}
+      role="button"
+      tabIndex={0}
     >
       <CardContent className="p-0 relative">
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent z-10"></div>

--- a/src/components/home/MapSection.tsx
+++ b/src/components/home/MapSection.tsx
@@ -42,7 +42,7 @@ const MapSection = () => {
           
           <div className="flex-1">
             <Card className="overflow-hidden border-none shadow-lg rounded-xl">
-              <div className="bg-kitloop-medium-gray h-96 relative">
+              <div className="bg-kitloop-medium-gray h-64 sm:h-80 lg:h-96 relative">
                 <div className="absolute inset-0 flex items-center justify-center">
                   <p className="text-muted-foreground">Interactive map showing nearby rental options would be displayed here</p>
                 </div>

--- a/src/components/home/SearchBar.tsx
+++ b/src/components/home/SearchBar.tsx
@@ -32,7 +32,7 @@ const SearchBar = () => {
       <div className="relative flex-grow">
         <Input
           placeholder={t('hero.search_placeholder')}
-          className="pl-10 py-6 bg-transparent border-kitloop-medium-gray focus:border-green-600"
+          className="pl-10 py-4 sm:py-6 bg-transparent border-kitloop-medium-gray focus:border-green-600"
           value={gearQuery}
           onChange={(e) => setGearQuery(e.target.value)}
         />
@@ -41,7 +41,7 @@ const SearchBar = () => {
       <div className="relative flex-grow">
         <Input
           placeholder={t('hero.location_placeholder')}
-          className="pl-10 py-6 bg-transparent border-kitloop-medium-gray focus:border-green-600"
+          className="pl-10 py-4 sm:py-6 bg-transparent border-kitloop-medium-gray focus:border-green-600"
           value={locationQuery}
           onChange={(e) => setLocationQuery(e.target.value)}
         />
@@ -53,7 +53,7 @@ const SearchBar = () => {
         type="submit"
         variant="primary"
         aria-label={t('hero.cta')}
-        className="py-6 px-10 text-lg md:text-xl shadow-lg whitespace-nowrap"
+        className="py-4 px-6 sm:py-6 sm:px-10 text-lg md:text-xl shadow-lg whitespace-nowrap"
       >
         {t('hero.cta')}
       </Button>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -20,7 +20,7 @@ const Footer = () => {
   return (
     <footer className="border-t bg-muted py-12 px-6">
       <div className="container mx-auto max-w-7xl">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-8 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8 mb-8">
           
           {/* About */}
           <div>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { Button } from "@/components/ui/button";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { Menu } from "lucide-react";
 import LanguageSwitcher from "./LanguageSwitcher";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
 
 const Navbar = () => {
   const navigate = useNavigate();
@@ -58,7 +64,35 @@ const Navbar = () => {
           <Button variant="outline" className="hidden md:flex" asChild>
             <Link to="/login">{t('navbar.sign_in')}</Link>
           </Button>
-          <Button variant="primary" asChild>
+          <Button variant="primary" className="hidden md:flex" asChild>
+            <Link to="/signup">{t('navbar.sign_up')}</Link>
+          </Button>
+
+          {/* Mobile menu */}
+          <Drawer>
+            <DrawerTrigger asChild>
+              <Button variant="ghost" size="icon" className="md:hidden">
+                <Menu className="h-6 w-6" />
+              </Button>
+            </DrawerTrigger>
+            <DrawerContent className="p-6 space-y-6">
+              <nav className="flex flex-col space-y-4 text-center text-text">
+                <Link to="/how-it-works">{t('navbar.how_it_works')}</Link>
+                <Link to="/browse">{t('navbar.browse_gear')}</Link>
+                <Link to="/about">{t('navbar.about_us')}</Link>
+                <button onClick={() => scrollToSection('faq')}>{t('navbar.faq')}</button>
+              </nav>
+              <div className="flex flex-col gap-3">
+                <Button variant="outline" asChild className="w-full">
+                  <Link to="/login">{t('navbar.sign_in')}</Link>
+                </Button>
+                <Button variant="primary" asChild className="w-full">
+                  <Link to="/signup">{t('navbar.sign_up')}</Link>
+                </Button>
+              </div>
+            </DrawerContent>
+          </Drawer>
+          <Button variant="primary" className="md:hidden" asChild>
             <Link to="/signup">{t('navbar.sign_up')}</Link>
           </Button>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,7 @@
 
 
   body {
-    @apply bg-kitloop-background text-kitloop-text;
+    @apply bg-kitloop-background text-kitloop-text overflow-x-hidden;
     font-family: 'Inter', sans-serif;
   }
 


### PR DESCRIPTION
## Summary
- tweak global body styles to avoid horizontal overflow
- add mobile drawer navigation
- refine hero searchbar padding
- ensure category cards have accessible hitboxes
- adjust map section height and footer grid layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687014b392e0832c8881c9c61c1016ef