### PR TITLE
Implement scaffolded provider dashboard routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,11 @@ import Terms from "./pages/Terms";
 import Privacy from "./pages/Privacy";
 import Navbar from "./components/layout/Navbar";
 import Footer from "./components/layout/Footer";
+import ProviderRoute from "./components/ProviderRoute";
+import DashboardOverview from "./pages/provider/DashboardOverview";
+import ProviderGear from "./pages/provider/ProviderGear";
+import ProviderReservations from "./pages/provider/ProviderReservations";
+import ProviderVerify from "./pages/provider/ProviderVerify";
 
 const queryClient = new QueryClient();
 
@@ -39,6 +44,38 @@ const App = () => (
               <Route path="/about" element={<About />} />
               <Route path="/terms" element={<Terms />} />
               <Route path="/privacy" element={<Privacy />} />
+              <Route
+                path="/provider/dashboard"
+                element={
+                  <ProviderRoute>
+                    <DashboardOverview />
+                  </ProviderRoute>
+                }
+              />
+              <Route
+                path="/provider/dashboard/gear"
+                element={
+                  <ProviderRoute>
+                    <ProviderGear />
+                  </ProviderRoute>
+                }
+              />
+              <Route
+                path="/provider/dashboard/reservations"
+                element={
+                  <ProviderRoute>
+                    <ProviderReservations />
+                  </ProviderRoute>
+                }
+              />
+              <Route
+                path="/provider/dashboard/verify"
+                element={
+                  <ProviderRoute>
+                    <ProviderVerify />
+                  </ProviderRoute>
+                }
+              />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/ProviderRoute.tsx
+++ b/src/components/ProviderRoute.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
+
+interface Props {
+  children: JSX.Element;
+}
+
+const ProviderRoute = ({ children }: Props) => {
+  const { user, isAuthenticated } = useAuth();
+
+  if (!isAuthenticated || user?.role !== 'provider' || !user?.approved) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+export default ProviderRoute;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -5,6 +5,8 @@ interface User {
   email: string;
   firstName?: string;
   lastName?: string;
+  role?: string;
+  approved?: boolean;
   isLoggedIn: boolean;
 }
 

--- a/src/pages/AddRental.tsx
+++ b/src/pages/AddRental.tsx
@@ -119,6 +119,7 @@ export default function AddRental() {
     } finally {
       setIsSubmitting(false);
     }
+  };
   return (
     <div className="flex items-center justify-center min-h-screen bg-kitloop-background px-4">
       <Card className="w-full max-w-xl shadow">

--- a/src/pages/provider/DashboardOverview.tsx
+++ b/src/pages/provider/DashboardOverview.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+const DashboardOverview = () => {
+  const { user } = useAuth();
+
+  return (
+    <div className="container mx-auto py-10 space-y-6">
+      <h1 className="text-2xl font-bold">Provider Dashboard</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>{user?.firstName || user?.email}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1 text-sm text-muted-foreground">
+          <p>Email: {user?.email}</p>
+          <p>Phone: ---</p>
+          <p>Website: ---</p>
+        </CardContent>
+      </Card>
+      <Tabs defaultValue="gear" className="w-full">
+        <TabsList>
+          <TabsTrigger value="gear" asChild>
+            <Link to="/provider/dashboard/gear">My Gear</Link>
+          </TabsTrigger>
+          <TabsTrigger value="reservations" asChild>
+            <Link to="/provider/dashboard/reservations">Reservations</Link>
+          </TabsTrigger>
+          <TabsTrigger value="verify" asChild>
+            <Link to="/provider/dashboard/verify">QR Scan</Link>
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+};
+
+export default DashboardOverview;

--- a/src/pages/provider/ProviderGear.tsx
+++ b/src/pages/provider/ProviderGear.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const mockGear = [
+  { id: 1, name: 'Tent', type: 'Camping', status: 'Available' },
+  { id: 2, name: 'Backpack', type: 'Hiking', status: 'Out' },
+];
+
+const ProviderGear = () => {
+  return (
+    <div className="container mx-auto py-10">
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-xl font-semibold">My Gear</h2>
+        <Button>Add New Gear</Button>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {mockGear.map((item) => (
+          <Card key={item.id} className="flex flex-col">
+            <CardHeader>
+              <CardTitle>{item.name}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm flex-grow">
+              <p className="text-muted-foreground">{item.type}</p>
+              <p>Status: {item.status}</p>
+              <div className="flex gap-2 mt-2">
+                <Button size="sm" variant="outline">Edit</Button>
+                <Button size="sm" variant="destructive">Delete</Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ProviderGear;

--- a/src/pages/provider/ProviderReservations.tsx
+++ b/src/pages/provider/ProviderReservations.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+const mockReservations = [
+  {
+    id: 1,
+    gear: 'Tent',
+    customer: 'Alice',
+    from: '2024-05-01',
+    to: '2024-05-03',
+    status: 'pending',
+  },
+];
+
+const ProviderReservations = () => {
+  return (
+    <div className="container mx-auto py-10 space-y-4">
+      <h2 className="text-xl font-semibold mb-4">Reservations</h2>
+      {mockReservations.map((res) => (
+        <Card key={res.id}>
+          <CardHeader>
+            <CardTitle>{res.gear}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <p className="text-muted-foreground">{res.customer}</p>
+            <p>
+              {res.from} – {res.to}
+            </p>
+            <Badge className="capitalize">{res.status}</Badge>
+            <div className="flex gap-2 mt-2">
+              <Button size="sm">Confirm pickup</Button>
+              <Button size="sm">Confirm return</Button>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default ProviderReservations;

--- a/src/pages/provider/ProviderVerify.tsx
+++ b/src/pages/provider/ProviderVerify.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+const ProviderVerify = () => {
+  const [code, setCode] = useState('');
+
+  return (
+    <div className="container mx-auto py-10">
+      <Card className="max-w-md mx-auto">
+        <CardHeader>
+          <CardTitle>Verify Customer</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            placeholder="Enter QR code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+          />
+          <Button className="w-full">Scan / Verify</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ProviderVerify;


### PR DESCRIPTION
## Summary
- add ProviderRoute wrapper for approved provider access
- extend AuthContext user type with optional role/approved flags
- fix AddRental closing brace
- scaffold provider dashboard subpages
- route `/provider/dashboard/*` paths through ProviderRoute

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687266de7388832c8543bb872b5da91a