### PR TITLE
feat: PR-B — Provider timezone-aware today dates (SSOT-ready)

### DIFF
--- a/docs/verification/TIMEZONE_RUNBOOK.md
+++ b/docs/verification/TIMEZONE_RUNBOOK.md
@@ -1,0 +1,35 @@
+# Pilot Runbook — Timezone Behavior
+
+## Current Behavior (F1 Pilot)
+
+The "Today List" dashboard triage determines "today" using the **provider's configured timezone** (`providers.time_zone`, IANA format, default: `Europe/Prague`).
+
+### How it works
+
+1. `getProviderTodayDates(provider.time_zone)` computes `todayDate` and `tomorrowDate` as `YYYY-MM-DD` strings in the provider's timezone.
+2. These strings are used directly in Supabase queries against `reservations.start_date` and `reservations.end_date` (Postgres `DATE` columns).
+3. **No `toISOString()`** — DATE columns don't need timestamps, so there's no UTC shift.
+
+### Fallback
+
+If `provider.time_zone` is `NULL` or invalid:
+
+- Falls back to the **operator's local browser clock** (same behavior as F1 pilot before timezone support).
+- A console warning is logged for invalid timezone strings.
+
+## Future Behavior (F3+)
+
+When multi-timezone support is needed:
+
+1. Admin sets `providers.time_zone` in Provider Settings.
+2. All date-based queries automatically use the provider's timezone.
+3. The `getProviderTodayDates` util is the single source of truth for "what day is it for this provider."
+
+## Technical Details
+
+| Component | Location |
+|-----------|----------|
+| Timezone util | `src/lib/provider-dates.ts` |
+| Dashboard hook | `src/hooks/useDashboardData.ts` |
+| DB column | `providers.time_zone` (text, default `'Europe/Prague'`) |
+| Implementation | `Intl.DateTimeFormat` with `en-CA` locale (native YYYY-MM-DD) |

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { format } from "date-fns";
+import { getProviderTodayDates } from "@/lib/provider-dates";
 import { AgendaItemProps, KpiData } from "@/types/dashboard";
 import { ExceptionItem } from "@/types/dashboard";
 import { toast } from "sonner";
@@ -36,13 +37,9 @@ export const useDashboardData = () => {
     const queryClient = useQueryClient();
 
     // DATE columns in reservations are Postgres DATE type.
-    // Use YYYY-MM-DD strings → no timezone shift, no implicit cast.
-    // F1 pilot: operator's local date (front-desk clock) is the source of truth.
-    const now = new Date();
-    const todayDate = format(now, 'yyyy-MM-dd');      // e.g. "2026-03-06"
-    const tomorrow = new Date(now);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    const tomorrowDate = format(tomorrow, 'yyyy-MM-dd'); // e.g. "2026-03-07"
+    // Use provider timezone to compute correct "today" boundary.
+    // Fallback: operator's local clock (F1 pilot default).
+    const { todayDate, tomorrowDate } = getProviderTodayDates(provider?.time_zone);
 
     // --- QUERIES ---
 

--- a/src/lib/provider-dates.ts
+++ b/src/lib/provider-dates.ts
@@ -1,0 +1,59 @@
+/**
+ * Provider-aware date utility for Today List triage.
+ *
+ * Uses provider's IANA timezone (from providers.time_zone) to compute
+ * the correct "today" boundary for DATE column comparisons.
+ *
+ * Fallback: operator's local clock (browser timezone) — preserves F1 pilot behavior.
+ *
+ * Returns YYYY-MM-DD strings matching Postgres DATE columns (no timestamp, no TZ shift).
+ */
+
+/**
+ * Compute today and tomorrow date strings in the given IANA timezone.
+ *
+ * @param timezone - IANA timezone string (e.g. 'Europe/Prague'). If nullish, uses browser local.
+ * @returns { todayDate: string; tomorrowDate: string } in YYYY-MM-DD format
+ */
+export function getProviderTodayDates(timezone?: string | null): {
+    todayDate: string;
+    tomorrowDate: string;
+} {
+    const now = new Date();
+
+    if (timezone) {
+        // Use Intl.DateTimeFormat to get the correct date in the provider's timezone.
+        // This avoids adding date-fns-tz as a dependency.
+        try {
+            const formatter = new Intl.DateTimeFormat('en-CA', {
+                timeZone: timezone,
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+            });
+            // en-CA locale formats as YYYY-MM-DD natively
+            const todayDate = formatter.format(now);
+
+            // Compute tomorrow: add 1 day in the provider's timezone
+            // We parse the provider-local date and add a day
+            const [year, month, day] = todayDate.split('-').map(Number);
+            const tomorrowLocal = new Date(year, month - 1, day + 1);
+            const tomorrowDate = formatter.format(tomorrowLocal);
+
+            return { todayDate, tomorrowDate };
+        } catch {
+            // Invalid timezone string → fall through to fallback
+            console.warn(`Invalid provider timezone "${timezone}", using local fallback.`);
+        }
+    }
+
+    // Fallback: operator's local clock (F1 pilot default behavior)
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const todayDate = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowDate = `${tomorrow.getFullYear()}-${pad(tomorrow.getMonth() + 1)}-${pad(tomorrow.getDate())}`;
+
+    return { todayDate, tomorrowDate };
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -31,10 +31,10 @@ export interface KpiData {
 
 export interface AgendaItemProps {
     time: string;
-    type: 'pickup' | 'return';
+    type: 'pickup' | 'return' | 'overdue';
     customerName: string;
     itemCount: number;
-    status: 'ready' | 'conflict' | 'unpaid' | 'active' | 'completed'; // UI state for the agenda row
+    status: 'ready' | 'conflict' | 'unpaid' | 'active' | 'completed' | 'overdue'; // UI state for the agenda row
     reservationId: string;
     startDate?: string;
     endDate?: string;


### PR DESCRIPTION
Adds timezone-aware date computation for the Today List triage.

- getProviderTodayDates(timezone?) util using Intl.DateTimeFormat
- Uses provider.time_zone (IANA, default Europe/Prague) from DB
- Fallback: operator's local clock (F1 backwards compatible)
- No new dependencies (built-in Intl API)
- AgendaItemProps type: added 'overdue' category
- docs/verification/TIMEZONE_RUNBOOK.md